### PR TITLE
Modify chainlink chart

### DIFF
--- a/charts/chainlink/templates/chainlink-cm.yaml
+++ b/charts/chainlink/templates/chainlink-cm.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: chainlink-cm
+    app: {{ .Release.Name }}-cm
     release: {{ .Release.Name }}
-  name: chainlink-cm
+  name: {{ .Release.Name }}-cm
 data:
   apicredentials: |
     notreal@fakeemail.ch

--- a/charts/chainlink/templates/chainlink-deployment.yaml
+++ b/charts/chainlink/templates/chainlink-deployment.yaml
@@ -1,25 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: chainlink-node
+  name: {{ .Release.Name }}-node
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: chainlink-node
+      app: {{ .Release.Name }}-node
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: chainlink-node
+        app: {{ .Release.Name }}-node
         release: {{ .Release.Name }}
       annotations:
         prometheus.io/scrape: 'true'
     spec:
       volumes:
-        - name: chainlink-config-map
+        - name: {{ .Release.Name }}-config-map
           configMap:
-            name: chainlink-cm
+            name: {{ .Release.Name }}-cm
       containers:
         - name: chainlink-db
           image: postgres:11.6
@@ -87,7 +87,7 @@ spec:
             {{- end }}
           {{- end }}
           volumeMounts:
-            - name: chainlink-config-map
+            - name: {{ .Release.Name }}-config-map
               mountPath: /etc/node-secrets-volume/
           livenessProbe:
             httpGet:

--- a/charts/chainlink/templates/chainlink-secret.yaml
+++ b/charts/chainlink/templates/chainlink-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: chainlink-node-creds-secret
+  name: {{ .Release.Name }}-node-creds-secret
 type: Opaque
 data:
   nodepassword: VC50TEhrY213ZVBUL3AsXXNZdW50andIS0FzcmhtIzRlUnM0THVLSHd2SGVqV1lBQzJKUDRNOEhpbXdnbWJhWgo=

--- a/charts/chainlink/templates/chainlink-service.yaml
+++ b/charts/chainlink/templates/chainlink-service.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: chainlink-service
-{{/*  generateName: chainlink-*/}}
+  name: {{ .Release.Name }}-service
+{{/*  generateName: {{ .Release.Name }}-*/}}
 spec:
   ports:
     - name: node-port
@@ -12,5 +12,5 @@ spec:
       port: {{ .Values.chainlink.p2p_port }}
       targetPort: {{ .Values.chainlink.p2p_port }}
   selector:
-    app: chainlink-node
+    app: {{ .Release.Name }}-node
   type: ClusterIP


### PR DESCRIPTION
Modify chainlink chart to be able to deploy the same chart multiple times.
This is needed because as part of e2e alert testing chainlink nodes need separate explorer secret keys

use case:
```
	for i := 0; i < nrOfNodes; i++ {
		values := map[string]interface{}{}
		values["env"] = map[string]interface{}{
			"explorer_url":        explorerLocalUrl,
			"explorer_access_key": nodeCredentials[i].AccessKey,
			"explorer_secret":     nodeCredentials[i].Secret,
		}

		name := fmt.Sprintf("chainlink-%d", i)
		err = e.AddChart(&environment.HelmChart{
			ReleaseName: name,
			Path:        filepath.Join(tools.ChartsRoot, "chainlink"),
			Index:       index,
		})
		index++
		Expect(err).ShouldNot(HaveOccurred())
		err = e.Deploy(name)
		Expect(err).ShouldNot(HaveOccurred())
		err = e.Connect(name)
		Expect(err).ShouldNot(HaveOccurred())
	}
```