### PR TITLE
Deploy and connect

### DIFF
--- a/environment/environment.go
+++ b/environment/environment.go
@@ -280,6 +280,27 @@ func (k *Environment) DeployAll() error {
 	return nil
 }
 
+// DeployAndConnectAll deploys and connects
+func (k *Environment) DeployAndConnectAll() error {
+	for _, keySlice := range k.Charts.OrderedKeys() {
+		group := &errgroup.Group{}
+		for _, key := range keySlice {
+			chart, ok := k.Charts[key]
+			if !ok {
+				continue
+			}
+			group.Go(chart.DeployAndConnect)
+		}
+		if err := group.Wait(); err != nil {
+			return err
+		}
+	}
+	if err := k.SyncConfig(); err != nil {
+		return err
+	}
+	return nil
+}
+
 // AddChart adds chart to deploy
 func (k *Environment) AddChart(chart *HelmChart) error {
 	if chart.Index == 0 {

--- a/environment/helm_chart.go
+++ b/environment/helm_chart.go
@@ -119,6 +119,16 @@ func (hc *HelmChart) Deploy() error {
 	return nil
 }
 
+func (hc *HelmChart) DeployAndConnect() error {
+	if err := hc.Deploy(); err != nil {
+		return err
+	}
+	if err := hc.Connect(); err != nil {
+		return err
+	}
+	return nil
+}
+
 // ExecuteInPod is similar to kubectl exec
 func (hc *HelmChart) ExecuteInPod(podName string, containerName string, command []string) ([]byte, []byte, error) {
 	req := hc.env.k8sClient.CoreV1().RESTClient().Post().


### PR DESCRIPTION
The addition of `func (hc *HelmChart) DeployAndConnect()` is motivated by the need to connect to local port of a deployed chart in the `AfterHook`

use case:
```
err = e.AddChart(&environment.HelmChart{
ReleaseName: "explorer",
Path:        filepath.Join("../charts", "explorer"),
Index:       index,
AfterHook: func(e *environment.Environment) error {

	explorerLocalUrl, err := e.Charts["explorer"].ChartConnections.LocalURLByPort("server", environment.HTTP)
	if err != nil {
		return err
	}
	explorerClient := client.NewExplorerClient(&client.ExplorerConfig{
		URL:           explorerLocalUrl.String(),
		AdminUsername: "username",
		AdminPassword: "password",
	})
	for i := 0; i < nrOfNodes; i++ {
		credentials, err := explorerClient.PostAdminNodes(fmt.Sprintf("node-%d", i))
		if err != nil {
			return err
		}
		nodeCredentials[fmt.Sprintf("chainlink-%d", i)] = credentials
	}
	return nil
},
})
```