### PR TITLE
update chaos experiments templates

### DIFF
--- a/chaos/experiments/container_kill.go
+++ b/chaos/experiments/container_kill.go
@@ -3,8 +3,10 @@ package experiments
 // ContainerKill struct for continer kill testing
 type ContainerKill struct {
 	Base
-	TargetAppLabel string
-	Container      string
+	Mode       string
+	LabelKey   string
+	LabelValue string
+	Container  string
 }
 
 // SetBase sets the base

--- a/chaos/experiments/cpu_chaos.go
+++ b/chaos/experiments/cpu_chaos.go
@@ -5,13 +5,15 @@ import "time"
 // CPUHog struct for cpu hog testing
 type CPUHog struct {
 	Base
-	TargetAppLabel string
-	Workers        int
-	Load           int
-	OptsCPU        int
-	OptsTimeout    int
-	OptsHDD        int
-	Duration       time.Duration
+	Mode        string
+	LabelKey    string
+	LabelValue  string
+	Workers     int
+	Load        int
+	OptsCPU     int
+	OptsTimeout int
+	OptsHDD     int
+	Duration    time.Duration
 }
 
 // SetBase sets the base

--- a/chaos/experiments/io_delay.go
+++ b/chaos/experiments/io_delay.go
@@ -5,12 +5,14 @@ import "time"
 // IODelay struct contains objects for IODelay testing
 type IODelay struct {
 	Base
-	TargetAppLabel string
-	VolumePath     string
-	Path           string
-	Delay          time.Duration
-	Percent        int
-	Duration       time.Duration
+	Mode       string
+	LabelKey   string
+	LabelValue string
+	VolumePath string
+	Path       string
+	Delay      time.Duration
+	Percent    int
+	Duration   time.Duration
 }
 
 // SetBase sets the base

--- a/chaos/experiments/io_fault.go
+++ b/chaos/experiments/io_fault.go
@@ -5,12 +5,14 @@ import "time"
 // IOFault struct contains objects for IO Fault testing
 type IOFault struct {
 	Base
-	TargetAppLabel string
-	VolumePath     string
-	Path           string
-	Errno          int
-	Percent        int
-	Duration       time.Duration
+	Mode       string
+	LabelKey   string
+	LabelValue string
+	VolumePath string
+	Path       string
+	Errno      int
+	Percent    int
+	Duration   time.Duration
 }
 
 // SetBase sets the base

--- a/chaos/experiments/network_bandwidth.go
+++ b/chaos/experiments/network_bandwidth.go
@@ -4,10 +4,12 @@ import (
 	"time"
 )
 
-// NetworkBandwidth struct with objects for Network Bandwidth testing
+// NetworkBandwidth struct with objects for NetworkConfig Bandwidth testing
 type NetworkBandwidth struct {
 	Base
-	TargetAppLabel string
+	Mode       string
+	LabelKey   string
+	LabelValue string
 	// kbps
 	Rate     string
 	Limit    int

--- a/chaos/experiments/network_corrupt.go
+++ b/chaos/experiments/network_corrupt.go
@@ -7,10 +7,12 @@ import (
 // NetworkCorrupt struct for network corruption
 type NetworkCorrupt struct {
 	Base
-	TargetAppLabel string
-	Corrupt        int
-	Correlation    int
-	Duration       time.Duration
+	Mode        string
+	LabelKey    string
+	LabelValue  string
+	Corrupt     int
+	Correlation int
+	Duration    time.Duration
 }
 
 // SetBase sets the base

--- a/chaos/experiments/network_delay.go
+++ b/chaos/experiments/network_delay.go
@@ -7,6 +7,7 @@ import (
 // NetworkDelay stuct containing definitions for a network delay
 type NetworkDelay struct {
 	Base
+	Mode       string
 	LabelKey   string
 	LabelValue string
 	Latency    time.Duration

--- a/chaos/experiments/network_duplicate.go
+++ b/chaos/experiments/network_duplicate.go
@@ -2,13 +2,15 @@ package experiments
 
 import "time"
 
-// NetworkDuplicate struct contains objects for Network Duplication testing
+// NetworkDuplicate struct contains objects for NetworkConfig Duplication testing
 type NetworkDuplicate struct {
 	Base
-	TargetAppLabel string
-	Duplicate      int
-	Correlation    int
-	Duration       time.Duration
+	Mode        string
+	LabelKey    string
+	LabelValue  string
+	Duplicate   int
+	Correlation int
+	Duration    time.Duration
 }
 
 // SetBase sets the base

--- a/chaos/experiments/network_loss.go
+++ b/chaos/experiments/network_loss.go
@@ -2,13 +2,15 @@ package experiments
 
 import "time"
 
-// NetworkLoss struct with objects for Network Loss testing
+// NetworkLoss struct with objects for NetworkConfig Loss testing
 type NetworkLoss struct {
 	Base
-	TargetAppLabel string
-	Loss           int
-	Correlation    int
-	Duration       time.Duration
+	Mode        string
+	LabelKey    string
+	LabelValue  string
+	Loss        int
+	Correlation int
+	Duration    time.Duration
 }
 
 // SetBase sets the base

--- a/chaos/experiments/network_partition.go
+++ b/chaos/experiments/network_partition.go
@@ -1,6 +1,6 @@
 package experiments
 
-// NetworkPartition struct with objects for Network Partition testing
+// NetworkPartition struct with objects for NetworkConfig Partition testing
 type NetworkPartition struct {
 	Base
 	FromMode       string

--- a/chaos/experiments/pod_failure.go
+++ b/chaos/experiments/pod_failure.go
@@ -7,6 +7,7 @@ import (
 // PodFailure struct contains objects for Pod Failure testing
 type PodFailure struct {
 	Base
+	Mode       string
 	LabelKey   string
 	LabelValue string
 	Duration   time.Duration

--- a/chaos/experiments/pod_kill.go
+++ b/chaos/experiments/pod_kill.go
@@ -3,7 +3,9 @@ package experiments
 // PodKill struct for pod kill testing
 type PodKill struct {
 	Base
-	TargetAppLabel string
+	Mode       string
+	LabelKey   string
+	LabelValue string
 }
 
 // SetBase sets the base

--- a/chaos/experiments/time_shift.go
+++ b/chaos/experiments/time_shift.go
@@ -2,12 +2,14 @@ package experiments
 
 import "time"
 
-// TimeShift stuct to contain info needed for TimeShift testing
+// TimeShift struct to contain info needed for TimeShift testing
 type TimeShift struct {
 	Base
-	TargetAppLabel string
-	TimeOffset     time.Duration
-	Duration       time.Duration
+	Mode       string
+	LabelKey   string
+	LabelValue string
+	TimeOffset time.Duration
+	Duration   time.Duration
 }
 
 // SetBase sets the base

--- a/chaos/templates/container-kill.yml
+++ b/chaos/templates/container-kill.yml
@@ -5,9 +5,9 @@ metadata:
   namespace: {{ .Base.Namespace }}
 spec:
   action: container-kill
-  mode: one
+  mode: {{ .Mode }}
   selector:
     labelSelectors:
-      'app': '{{ .TargetAppLabel }}'
+      '{{ .LabelKey }}': '{{ .LabelValue }}'
   containerNames:
     - {{ .Container }}

--- a/chaos/templates/cpu-chaos.yml
+++ b/chaos/templates/cpu-chaos.yml
@@ -4,10 +4,10 @@ metadata:
   name: {{ .Base.Name }}
   namespace: {{ .Base.Namespace }}
 spec:
-  mode: one
+  mode: {{ .Mode }}
   selector:
     labelSelectors:
-      'app': '{{ .TargetAppLabel }}'
+      '{{ .LabelKey }}': '{{ .LabelValue }}'
   stressors:
     cpu:
       workers: {{ .Workers }}

--- a/chaos/templates/io-delay.yml
+++ b/chaos/templates/io-delay.yml
@@ -5,10 +5,10 @@ metadata:
   namespace: {{ .Base.Namespace }}
 spec:
   action: latency
-  mode: one
+  mode: {{ .Mode }}
   selector:
     labelSelectors:
-      'app': '{{ .TargetAppLabel }}'
+      '{{ .LabelKey }}': '{{ .LabelValue }}'
   volumePath: {{ .VolumePath }}
   path: {{ .Path }}
   delay: {{ .Delay }}

--- a/chaos/templates/io-fault.yml
+++ b/chaos/templates/io-fault.yml
@@ -5,10 +5,10 @@ metadata:
   namespace: {{ .Base.Namespace }}
 spec:
   action: fault
-  mode: one
+  mode: {{ .Mode }}
   selector:
     labelSelectors:
-      'app': '{{ .TargetAppLabel }}'
+      '{{ .LabelKey }}': '{{ .LabelValue }}'
   volumePath: {{ .VolumePath }}
   path: {{ .Path }}
   errno: {{ .Errno }}

--- a/chaos/templates/network-bandwidth.yml
+++ b/chaos/templates/network-bandwidth.yml
@@ -5,10 +5,10 @@ metadata:
   namespace: {{ .Base.Namespace }}
 spec:
   action: bandwidth
-  mode: one
+  mode: {{ .Mode }}
   selector:
     labelSelectors:
-      'app': '{{ .TargetAppLabel }}'
+      '{{ .LabelKey }}': '{{ .LabelValue }}'
   bandwidth:
     rate: {{ .Rate }}
     limit: {{ .Limit }}

--- a/chaos/templates/network-corrupt.yml
+++ b/chaos/templates/network-corrupt.yml
@@ -5,10 +5,10 @@ metadata:
   namespace: {{ .Base.Namespace }}
 spec:
   action: corrupt
-  mode: one
+  mode: {{ .Mode }}
   selector:
     labelSelectors:
-      'app': '{{ .TargetAppLabel }}'
+      '{{ .LabelKey }}': '{{ .LabelValue }}'
   corrupt:
     corrupt: "{{ .Corrupt }}"
     correlation: "{{ .Correlation }}"

--- a/chaos/templates/network-delay.yml
+++ b/chaos/templates/network-delay.yml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Base.Name }}
 spec:
   action: delay
-  mode: one
+  mode: {{ .Mode }}
   selector:
     namespaces:
       - {{ .Base.Namespace }}

--- a/chaos/templates/network-duplicate.yml
+++ b/chaos/templates/network-duplicate.yml
@@ -5,11 +5,11 @@ metadata:
   namespace: {{ .Base.Namespace }}
 spec:
   action: duplicate
-  mode: one
+  mode: {{ .Mode }}
   selector:
     labelSelectors:
-      'app': '{{ .TargetAppLabel }}'
+      '{{ .LabelKey }}': '{{ .LabelValue }}'
   duplicate:
     duplicate: '{{ .Duplicate }}'
     correlation: '{{ .Correlation }}'
-  duration: {{ .Duration}}
+  duration: {{ .Duration }}

--- a/chaos/templates/network-loss.yml
+++ b/chaos/templates/network-loss.yml
@@ -5,10 +5,10 @@ metadata:
   namespace: {{ .Base.Namespace }}
 spec:
   action: loss
-  mode: one
+  mode: {{ .Mode }}
   selector:
     labelSelectors:
-      'app': '{{ .TargetAppLabel }}'
+      '{{ .LabelKey }}': '{{ .LabelValue }}'
   loss:
     loss: '{{ .Loss }}'
     correlation: '{{ .Correlation }}'

--- a/chaos/templates/pod-failure.yml
+++ b/chaos/templates/pod-failure.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Base.Namespace }}
 spec:
   action: pod-failure
-  mode: one
+  mode: {{ .Mode }}
   duration: {{ .Duration }}
   selector:
     labelSelectors:

--- a/chaos/templates/pod-kill.yml
+++ b/chaos/templates/pod-kill.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Base.Namespace }}
 spec:
   action: pod-kill
-  mode: one
+  mode: {{ .Mode }}
   selector:
     labelSelectors:
-      'app': '{{ .TargetAppLabel }}'
+      '{{ .LabelKey }}': '{{ .LabelValue }}'

--- a/chaos/templates/time-shift.yml
+++ b/chaos/templates/time-shift.yml
@@ -4,9 +4,9 @@ metadata:
   name: {{ .Base.Name }}
   namespace: {{ .Base.Namespace }}
 spec:
-  mode: one
+  mode: {{ .Mode }}
   selector:
     labelSelectors:
-      'app': '{{ .TargetAppLabel }}'
+      '{{ .LabelKey }}': '{{ .LabelValue }}'
   timeOffset: "{{ .TimeOffset }}"
   duration: "{{ .Duration }}"


### PR DESCRIPTION
Updates all chaos templates to use mode: one or many, and at least one key-value selector to target pods with different labels.