### PR TITLE
Greatly Improve Soak Runner Process

### DIFF
--- a/charts/remote-test-runner/templates/test-runner-config-map.yaml
+++ b/charts/remote-test-runner/templates/test-runner-config-map.yaml
@@ -9,25 +9,29 @@ data:
   test-env.json: |
     {{ .Values.remote_test_runner.config_file_contents }}
   init.sh: |
-    #!/bin/bash
-    apk update
-    apk add --no-cache git
-    echo "Installed Git"
+    #!/bin/sh
+    TEST_FILE=/root/remote.test
 
-    git version
-    echo "Cloning {{ .Values.remote_test_runner.clone_repo }} on branch {{ .Values.remote_test_runner.clone_repo_branch }}"
-    git clone --depth 1 -b {{ .Values.remote_test_runner.clone_repo_branch }} {{ .Values.remote_test_runner.clone_repo }} test-folder
-    echo "Cloned {{ .Values.remote_test_runner.clone_repo }} on branch {{ .Values.remote_test_runner.clone_repo_branch }}"
-    
-    cd test-folder
-    echo "Folder Contents"
-    ls
-    echo "Downloading go dependencies"
-    go mod download
-    echo "Downloaded go dependencies"
+    for i in 1 2 3 4 5 6 7 8 9 10
+    do
+      if [ -f "$TEST_FILE" ]
+      then
+        echo "$TEST_FILE found!"
+        if [ -z "$(lsof | grep "$TEST_FILE")" ]
+        then
+          chmod +x /root/remote.test
+          /root/remote.test --ginkgo.v --ginkgo.focus {{ .Values.remote_test_runner.test_name }}
+          break
+        else
+          lsof | grep "$TEST_FILE"
+          echo "$TEST_FILE is still being copied, waiting for copy process to finish"
+        fi
+        echo "Waiting for copy process to finalize"
+        
+      fi
+      ls /root
+      
+      sleep 10
+    done
 
-    echo "Building tests in {{ .Values.remote_test_runner.test_suite_directory }}"
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -c {{ .Values.remote_test_runner.test_suite_directory }} -o remote.test
-    chmod +x ./remote.test
-    echo "Built tests into './remote.test', running now"
-    ./remote.test --ginkgo.timeout=0 --ginkgo.focus {{ .Values.remote_test_runner.test_name }}
+    echo "Either the test has completed, or the test file failed to be uploaded in time"

--- a/charts/remote-test-runner/templates/test-runner-pod.yaml
+++ b/charts/remote-test-runner/templates/test-runner-pod.yaml
@@ -10,8 +10,7 @@ spec:
         name: remote-test-runner-cm
   containers:
     - name: remote-test-runner
-      image: golang:alpine
-      imagePullPolicy: Always
+      image: alpine
       command: ["sh", "/root/init.sh"]
       volumeMounts:
         - name : configmap-volume
@@ -25,6 +24,16 @@ spec:
           value: /root/test-env.json
         - name: SLACK_WEBHOOK
           value: {{ .Values.remote_test_runner.slack_webhook }}
+        - name: SLACK_API
+          value: {{ .Values.remote_test_runner.slack_api }}
+        - name: "GOOS"
+          value: "linux"
+        - name: "GOARCH"
+          value: "amd64"
+        - name: "FRAMEWORK_CONFIG_FILE"
+          value: /root/framework.yaml
+        - name: "NETWORKS_CONFIG_FILE"
+          value: /root/networks.yaml
       resources:
         requests:
           memory: {{ .Values.resources.requests.memory }}

--- a/charts/remote-test-runner/values.yaml
+++ b/charts/remote-test-runner/values.yaml
@@ -1,15 +1,13 @@
 remote_test_runner:
-  clone_repo: git://github.com/smartcontractkit/integrations-framework.git
-  clone_repo_branch: main
-  test_suite_directory: ./suite/soak/tests/
-  test_name: ocr
+  test_name: "@soak-ocr"
   config_file_contents: should be auto generated
   slack_webhook: https://hooks.slack.com/services/
+  slack_api: abcdefg
 
 resources:
   requests:
-    cpu: 1000m
-    memory: 2048Mi
+    cpu: 500m
+    memory: 512Mi
   limits:
-    cpu: 1000m
-    memory: 2048Mi
+    cpu: 500m
+    memory: 512Mi

--- a/charts/remote-test-runner/values.yaml
+++ b/charts/remote-test-runner/values.yaml
@@ -6,8 +6,8 @@ remote_test_runner:
 
 resources:
   requests:
-    cpu: 500m
-    memory: 512Mi
+    cpu: 100m
+    memory: 128Mi
   limits:
-    cpu: 500m
-    memory: 512Mi
+    cpu: 100m
+    memory: 128Mi

--- a/environment/artifacts.go
+++ b/environment/artifacts.go
@@ -55,6 +55,7 @@ func (a *Artifacts) writePodArtifacts(testDir string) error {
 		log.Err(err).
 			Str("Namespace", a.env.Config.NamespacePrefix).
 			Msg("Error retrieving pod list from K8s environment")
+		return err
 	}
 	for _, pod := range podsList.Items {
 		log.Info().

--- a/environment/helm_chart.go
+++ b/environment/helm_chart.go
@@ -163,7 +163,16 @@ func (hc *HelmChart) CopyToPod(src string, dst string, containername string) (*b
 	copyOptions.Clientset = hc.env.k8sClient
 	copyOptions.ClientConfig = hc.env.k8sConfig
 	copyOptions.Container = containername
-	err := copyOptions.Run([]string{src, dst})
+	copyOptions.Namespace = hc.env.Namespace
+	destString := fmt.Sprintf("%s/%s:%s", hc.env.Namespace, hc.ReleaseName, dst)
+	log.Debug().
+		Str("Namespace", hc.env.Namespace).
+		Str("Chart", hc.ReleaseName).
+		Str("Source", src).
+		Str("Destination", destString).
+		Str("Container", containername).
+		Msg("Uploading file to pod")
+	err := copyOptions.Run([]string{src, destString})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("Could not run copy operation: %v", err)
 	}


### PR DESCRIPTION
This is part 1/2 of a large overhaul to how the `remote_test_runner` operates and makes the process of setting up and running soak tests about 1000x easier.

Before, you had to make any test changes, commit them to a public git repo, and use a powerful container to pull and compile those tests, then run them. Now tests are built locally and uploaded to a minimal container. This comes with a lot of benefits:

1. Less points of failure
2. Less confusion on what needs to be committed and what doesn't
3. Cuts down on errors where slack API keys or webhooks would get pushed to public git repos
4. Enables local changes to tests to be realized without pushing to a public git branch
5. Faster compilation and overall execution time
6. Much smaller container needed to run the tests (Previously needed a full CPU and 2 gigs of RAM, the new one needs a 10th of the CPU and 128 MB of RAM)