### PR TITLE
release envcli versions when tags are pushed

### DIFF
--- a/.github/actions/golang-version/action.yml
+++ b/.github/actions/golang-version/action.yml
@@ -1,0 +1,17 @@
+name: Golang-Version
+description: Gets the golang version from the .tool-versions file
+
+outputs:
+  go-version:
+    description: "The golang version from the .tool-versions file"
+    value: ${{ steps.get-go-version.outputs.go-version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Go version
+      id: get-go-version
+      shell: bash
+      run: |
+        GO_VERSION=$(cat ./.tool-versions | grep golang | sed -En "s/golang (.*)/\1/p")
+        echo "::set-output name=go-version::${GO_VERSION}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,8 +2,7 @@ name: Linting
 on:
   pull_request:
     branches: [master]
-  schedule:
-    - cron: '23 19 * * 4'
+    
 jobs:
   golangci:
     name: Linting
@@ -11,24 +10,28 @@ jobs:
     steps:
       - name: Check out Code
         uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v2
+      - uses: ./.github/actions/golang-version
+        id: go-version
+      - name: Install Go ${{ steps.go-version.outputs.go-version }}
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ steps.go-version.outputs.go-version }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
 
-  vulnerabilities-check:  
+  vulnerabilities-check:
     name: Check for Vulnerabilities
     runs-on: ubuntu-latest
     steps:
-    - name: Check out Code
-      uses: actions/checkout@v3
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
-    - name: Write Go List
-      run: go list -json -deps ./... > go.list
-    - name: Nancy
-      uses: sonatype-nexus-community/nancy-github-action@main
+      - name: Check out Code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/golang-version
+        id: go-version
+      - name: Install Go ${{ steps.go-version.outputs.go-version }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ steps.go-version.outputs.go-version }}
+      - name: Write Go List
+        run: go list -json -deps ./... > go.list
+      - name: Nancy
+        uses: sonatype-nexus-community/nancy-github-action@main

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: ["master"]
   schedule:
-    - cron: '23 19 * * 4'
+    - cron: "23 19 * * 4"
 jobs:
   codeQL:
     name: CodeQL Checks

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,29 @@
+name: "Release a tag"
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/golang-version
+        id: go-version
+      - name: Install Go ${{ steps.go-version.outputs.go-version }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ steps.go-version.outputs.go-version }}
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Create release
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ bin/
 # Testing log dumps
 environment/test-artifacts/
 charts-test-file.json
+
+# goreleaser build
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,11 +21,6 @@ builds:
       - hardfloat
     env:
       - CGO_ENABLED=0
-    ignore:
-      - goos: darwin
-        goarch: 386
-      - goos: freebsd
-        goarch: arm64
     main: cmd/cli/envcli.go
     flags:
       - -trimpath

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,62 @@
+project_name: helmenv
+
+release:
+  github:
+    owner: smartcontractkit
+    name: envcli
+
+builds:
+  - binary: envcli
+    goos:
+      - darwin
+      - windows
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    goarm:
+      - 6
+      - 7
+    gomips:
+      - hardfloat
+    env:
+      - CGO_ENABLED=0
+    ignore:
+      - goos: darwin
+        goarch: 386
+      - goos: freebsd
+        goarch: arm64
+    main: cmd/cli/envcli.go
+    flags:
+      - -trimpath
+    ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+
+archives:
+  - format: tar.gz
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    files:
+      - LICENSE
+      - README.md
+
+snapshot:
+  name_template: SNAPSHOT-{{ .Commit }}
+
+checksum:
+  name_template: '{{ .ProjectName }}-{{ .Version }}-checksums.txt'
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '(?i)^docs?:'
+      - '(?i)^docs\([^:]+\):'
+      - '(?i)^docs\[[^:]+\]:'
+      - '^tests?:'
+      - '(?i)^dev:'
+      - '^build\(deps\): bump .* in /docs \(#\d+\)'
+      - Merge pull request
+      - Merge branch

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,4 @@
-golang 1.17.8
+golang 1.18
+golangci-lint 1.45.2
+k3d 5.4.1
+act 0.2.26

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,25 @@ BIN_DIR = bin
 export GOPATH ?= $(shell go env GOPATH)
 export GO111MODULE ?= on
 
+LINUX=LINUX
+OSX=OSX
+WINDOWS=WIN32
+OSFLAG :=
+ifeq ($(OS),Windows_NT)
+	OSFLAG = $(WINDOWS)
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		OSFLAG = $(LINUX)
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		OSFLAG = $(OSX)
+	endif
+endif
+
 .PHONY: lint
 lint: ## run linter
-	${BIN_DIR}/golangci-lint --color=always run ./... -v
-
-.PHONY: golangci
-golangci: ## install golangci-linter
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${BIN_DIR} v1.42.0
+	golangci-lint --color=always run ./... -v
 
 .PHONY: test
 test: # run all programmatic interaction tests
@@ -17,3 +29,21 @@ test: # run all programmatic interaction tests
 .PHONY: install_cli
 install_cli: # installs CLI
 	go install cmd/cli/envcli.go
+
+install_tools:
+ifeq ($(OSFLAG),$(WINDOWS))
+	echo "If you are running windows and know how to install what is needed, please contribute by adding it here!"
+	exit 1
+endif
+ifeq ($(OSFLAG),$(LINUX))
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${BIN_DIR} v$(shell cat ./.tool-versions | grep golangci-lint | sed -En "s/golangci-lint.(.*)/\1/p")
+	# TODO: golang, k3d, act
+endif
+ifeq ($(OSFLAG),$(OSX))
+	brew install asdf
+	asdf plugin-add golang https://github.com/kennyp/asdf-golang.git || true
+	asdf plugin add k3d https://github.com/spencergilbert/asdf-k3d.git || true
+	asdf plugin add act https://github.com/grimoh/asdf-act.git || true
+	asdf plugin add golangci-lint https://github.com/hypnoglow/asdf-golangci-lint.git || true
+	asdf install
+endif

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/helmenv
 
-go 1.17
+go 1.18
 
 require (
 	github.com/cavaliercoder/grab v2.0.0+incompatible


### PR DESCRIPTION
- Uses goreleaser to create executables for a set of operating systems including windows, linux, and mac (both intel and M1).
- The release format using the tags can be used for an asdf plugin to pull versions the same we are doing for other tools so we can put the version in .tool-versions files in projects to spin up test environments.