### PR TITLE
Fixed collecting pod logs

### DIFF
--- a/environment/charts/remote-test-runner/templates/role-read-bindings.yaml
+++ b/environment/charts/remote-test-runner/templates/role-read-bindings.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-reader
+subjects:
+  - kind: ServiceAccount
+    name: default


### PR DESCRIPTION
To fix the error:
```
11:05AM ERR Error retrieving pod list from K8s environment error="pods is forbidden: User \"system:serviceaccount:chainlink-soak-keeper-m87bs:default\" cannot list resource \"pods\" in API group \"\" in the namespace \"chainlink-soak-keeper-m87bs\"" Namespace=chainlink-soak-keeper
11:05AM WRN Error trying to collect pod logs error="pods is forbidden: User \"system:serviceaccount:chainlink-soak-keeper-m87bs:default\" cannot list resource \"pods\" in API group \"\" in the namespace \"chainlink-soak-keeper-m87bs\""
11:05AM WRN Unable to gather logs from a remote_test_runner instance. Working on improving this.
```